### PR TITLE
Merge upstream changes and fix DependencyControl feed

### DIFF
--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -15,20 +15,21 @@
       "description": "Cycles blur, border, shadow, alpha, etc.",
       "channels": {
         "master": {
-          "version": "2.0.0",
-          "released": "2018-06-10",
+          "version": "2.0.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "a6609d07ecc9738c85f1c91e58d3e0592763e425"
+              "sha1": "1381d1d6cf582d7887582389c1e7a71e309b16e6"
             }
           ]
         }
       },
       "changelog": {
-        "2.0.0": ["Check the Updates page"]
+        "2.0.0": ["Check the Updates page"],
+        "2.0.1": ["Move to TypesettingTools repository"]
       }
     },
     
@@ -39,20 +40,21 @@
       "description": "Italy Bold Under Strike",
       "channels": {
         "master": {
-          "version": "1.7.0",
-          "released": "2015-06-01",
+          "version": "1.7.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "b28cfc2d78584c1acaa2a22f170e9049b56dfe60"
+              "sha1": "688f4fa8f9575c6e0321b97147acd21993f39cb2"
             }
           ]
         }
       },
       "changelog": {
-        "1.7.0": ["merged Italics and Bold scripts and added Underline and Strikeout; added DependencyControl"]
+        "1.7.0": ["merged Italics and Bold scripts and added Underline and Strikeout; added DependencyControl"],
+        "1.7.1": ["Move to TypesettingTools repository"]
       }
     },
     
@@ -63,20 +65,21 @@
       "description": "insert/shift linebreaks",
       "channels": {
         "master": {
-          "version": "2.4.0",
-          "released": "2018-06-24",
+          "version": "2.4.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "90ef136b00345ee52c448054e52a0b1baeb149d5"
+              "sha1": "24c02a8aab629f27072658569de7fe880e6f7067"
             }
           ]
         }
       },
       "changelog": {
-        "2.4.0": ["Check the Updates page"]
+        "2.4.0": ["Check the Updates page"],
+        "2.4.1": ["Move to TypesettingTools repository"]
       }
     },
     
@@ -87,21 +90,22 @@
       "description": "Joins lines / splits lines / snaps to keyframes",
       "channels": {
         "master": {
-          "version": "1.2.0",
-          "released": "2015-06-20",
+          "version": "1.2.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "8fcc18612dd519088092309db8fc11cbbe29b97e"
+              "sha1": "a77565ccef8d9e7c3eedb889a4811da06f258ec9"
             }
           ]
         }
       },
       "changelog": {
+        "1.1.0": ["merged all three for convenience; changed how Join works; added DependencyControl"],
         "1.2.0": ["improved snapping to adjacent lines"],
-        "1.1.0": ["merged all three for convenience; changed how Join works; added DependencyControl"]
+        "1.2.1": ["Move to TypesettingTools repository"]
       }
     },
     
@@ -112,21 +116,22 @@
       "description": "Jumps to next 'sign' in the subtitle grid",
       "channels": {
         "master": {
-          "version": "2.0.0",
-          "released": "2015-06-01",
+          "version": "2.0.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "3befd2d8adca2d5fdfd93c30cbdfa770e258b4c2"
+              "sha1": "4fc6ab952bd051eba2a5de9cba14399b10831dc3"
             }
           ]
         }
       },
       "changelog": {
+        "1.3.0": ["Added DependencyControl"],
         "2.0.0": ["13 macros; Text/Style/Actor/Effect/Layer/CommentedLine x Next/Previous = 12 hotkeys + 1 for GUI version with all 12 options"],
-	"1.3.0": ["Added DependencyControl"]
+        "2.0.1": ["Move to TypesettingTools repository"]
       }
     },
     
@@ -137,20 +142,21 @@
       "description": "Removes selected stuff from script",
       "channels": {
         "master": {
-          "version": "5.0.0",
-          "released": "2018-06-10",
+          "version": "5.0.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "43addccdac9a6a7bc85ded9450075edb767df5f3"
+              "sha1": "bb0207d66c83291c97ff538ceb5958d73161eb9e"
             }
           ]
         }
       },
       "changelog": {
-        "5.0.0": ["Check the Updates page"]
+        "5.0.0": ["Check the Updates page"],
+        "5.0.1": ["Move to TypesettingTools repository"]
       }
     },
     
@@ -161,20 +167,21 @@
       "description": "Adds blur and/or glow to signs",
       "channels": {
         "master": {
-          "version": "2.5.0",
-          "released": "2015-06-01",
+          "version": "2.5.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "0cd79d224b84cca58ae1b201b36658536d635a10"
+              "sha1": "2871bc0e2b8ee05a96c3561827c3870d6dc5474e"
             }
           ]
         }
       },
       "changelog": {
-        "2.5.0": ["default blur part of config; cleaned up the code a bit; added DespondencyControl"]
+        "2.5.0": ["default blur part of config; cleaned up the code a bit; added DespondencyControl"],
+        "2.5.1": ["Move to TypesettingTools repository"]
       }
     },
     
@@ -185,20 +192,21 @@
       "description": "A multi-headed typesetting tool",
       "channels": {
         "master": {
-          "version": "6.1.0",
-          "released": "2018-08-05",
+          "version": "6.1.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "60adc9eda4c235afa7fae3a19be48fa1d2246b60"
+              "sha1": "7bd78f7251afbd07399d139224374c3a15a7a0e1"
             }
           ]
         }
       },
       "changelog": {
-        "6.1.0": ["Check the Updates page"]
+        "6.1.0": ["Check the Updates page"],
+        "6.1.1": ["Move to TypesettingTools repository"]
       }
     },
     
@@ -209,22 +217,23 @@
       "description": "Advanced metamorphosis of multidimensional coordinates",
       "channels": {
         "master": {
-          "version": "4.5.2",
-          "released": "2022-04-24",
+          "version": "4.5.3",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "e7a4e9f28363aa2deb27c3eab112dbd7d2d1ac73"
+              "sha1": "f40cb424dedd70e79fe3fb813b5ca63af60a174f"
             }
           ]
         }
       },
       "changelog": {
-	"4.5.2": ["Follow user defined rounding for vector clips"],
+        "4.5.0": ["Check the Updates page"],
         "4.5.1": ["Support for subpixel vector clips"],
-        "4.5.0": ["Check the Updates page"]
+        "4.5.2": ["Follow user defined rounding for vector clips"],
+        "4.5.3": ["Move to TypesettingTools repository"]
       }
     },
     
@@ -235,20 +244,21 @@
       "description": "recalculates things",
       "channels": {
         "master": {
-          "version": "4.0.0",
-          "released": "2018-05-13",
+          "version": "4.0.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "5aefde4e05f278f37d6956fc36ab03da4ffb59ab"
+              "sha1": "b1ad5b202dbf5d3eb92c8d545ae66dd04d41b824"
             }
           ]
         }
       },
       "changelog": {
-        "4.0.0": ["Check the Updates page"]
+        "4.0.0": ["Check the Updates page"],
+        "4.0.1": ["Move to TypesettingTools repository"]
       }
     },
     
@@ -259,20 +269,24 @@
       "description": "Does things with colours",
       "channels": {
         "master": {
-          "version": "5.0.0",
-          "released": "2018-06-10",
+          "version": "5.0.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "80d932bfc186761914cc56a1ecae685cfde2af26"
+              "sha1": "198ca530522307a5461301e08f0451d2537db889"
             }
           ]
         }
       },
       "changelog": {
-        "4.5.0": ["Check the Updates page"]
+        "4.5.0": ["Check the Updates page"],
+        "5.0.1": [
+          "Move to TypesettingTools repository",
+          "Change script_namespace to ua.Colorize"
+        ]
       }
     },
     
@@ -283,20 +297,21 @@
       "description": "Selectricks and Sortricks",
       "channels": {
         "master": {
-          "version": "3.4.0",
-          "released": "2018-08-05",
+          "version": "3.4.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "ab007be53835586317f779874b1d5f3af1c3f107"
+              "sha1": "a3891e5855847f68eeb4de8e53abf518af126196"
             }
           ]
         }
       },
       "changelog": {
-        "3.4.0": ["Check the Updates page"]
+        "3.4.0": ["Check the Updates page"],
+        "3.4.1": ["Move to TypesettingTools repository"]
       }
     },
     
@@ -307,20 +322,21 @@
       "description": "Capitalises text or makes it lowercase / uppercase",
       "channels": {
         "master": {
-          "version": "3.0.0",
-          "released": "2015-06-01",
+          "version": "3.0.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "6f429be4c75ea4fa6f49481ba99a9eef437d2db7"
+              "sha1": "b35d43343652343fcf4f682c3044f5e73b6bc18e"
             }
           ]
         }
       },
       "changelog": {
-        "3.0.0": ["improved; added options; unicode support; added DespondencyControl"]
+        "3.0.0": ["improved; added options; unicode support; added DespondencyControl"],
+        "3.0.1": ["Move to TypesettingTools repository"]
       }
     },
     
@@ -331,20 +347,21 @@
       "description": "Multi-Line Editor",
       "channels": {
         "master": {
-          "version": "1.8.0",
-          "released": "2018-05-13",
+          "version": "1.8.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "04bba9479f96bff8a19160183a0ab548d42031c3"
+              "sha1": "0bf75916a970620ca04837422570f22f68067eb4"
             }
           ]
         }
       },
       "changelog": {
-        "1.8.0": ["Check the Updates page"]
+        "1.8.0": ["Check the Updates page"],
+        "1.8.1": ["Move to TypesettingTools repository"]
       }
     },
     
@@ -355,20 +372,21 @@
       "description": "Copy and paste just about anything from/to multiple lines",
       "channels": {
         "master": {
-          "version": "4.0.0",
-          "released": "2019-08-18",
+          "version": "4.0.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "eba606e5893845ddc2a6065bc4c1d11fadea38c8"
+              "sha1": "de65e04394a2031599e70cbde277ca65e972db9b"
             }
           ]
         }
       },
       "changelog": {
-        "4.0.0": ["Check the Updates page"]
+        "4.0.0": ["Check the Updates page"],
+        "4.0.1": ["Move to TypesettingTools repository"]
       }
     },
     
@@ -379,20 +397,24 @@
       "description": "Works with Fades",
       "channels": {
         "master": {
-          "version": "5.0.0",
-          "released": "2019-08-18",
+          "version": "5.0.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "8eb5d146b2df485cc3fe211f07c25a9f02752d46"
+              "sha1": "b8703f84c6411c7e8cc268e4882504e2f87e958b"
             }
           ]
         }
       },
       "changelog": {
-        "5.0.0": ["Check the Updates page"]
+        "5.0.0": ["Check the Updates page"],
+        "5.0.1": [
+          "Move to TypesettingTools repository",
+          "Change script_namespace to ua.FadeWorks"
+        ]
       }
     },
     
@@ -403,20 +425,21 @@
       "description": "Import stuff, number stuff, chapter stuff, replace stuff, do a significant amount of other stuff to stuff.",
       "channels": {
         "master": {
-          "version": "3.5.0",
-          "released": "2019-08-18",
+          "version": "3.5.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "9e79c895d1578db74cc1fb6816c05b80eb85e1d5"
+              "sha1": "ae21070690f7fe13d1eb149305530bdd5d8ed452"
             }
           ]
         }
       },
       "changelog": {
-        "3.5.0": ["Check the Updates page"]
+        "3.5.0": ["Check the Updates page"],
+        "3.5.1": ["Move to TypesettingTools repository"]
       }
     },
     
@@ -427,20 +450,21 @@
       "description": "Time Machine.",
       "channels": {
         "master": {
-          "version": "3.1.0",
-          "released": "2019-08-18",
+          "version": "3.1.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "a379c8f79b5db37e3eb3de5f505425b696621155"
+              "sha1": "c9f3f88bbf37e412e5813c8e8f0f9aa39aea233a"
             }
           ]
         }
       },
       "changelog": {
-        "3.1.0": ["Check the Updates page"]
+        "3.1.0": ["Check the Updates page"],
+        "3.1.1": ["Move to TypesettingTools repository"]
       }
     },
     
@@ -451,20 +475,21 @@
       "description": "Rough-times signs from TS timecodes",
       "channels": {
         "master": {
-          "version": "2.8.0",
-          "released": "2015-05-28",
+          "version": "2.8.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "8e2a45a70f88cfa28abca22673e455dee95715d3"
+              "sha1": "3c27a47c343e99562fa86203b48b561a30a1a83a"
             }
           ]
         }
       },
       "changelog": {
-        "2.8.0": ["Added DespondencyControl"]
+        "2.8.0": ["Added DespondencyControl"],
+        "2.8.1": ["Move to TypesettingTools repository"]
       }
     },
     
@@ -475,20 +500,21 @@
       "description": "Masquerade",
       "channels": {
         "master": {
-          "version": "3.0.0",
-          "released": "2018-06-10",
+          "version": "3.0.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "49b217a9706196222719ff25117907d8c9c08f07"
+              "sha1": "7bdd4391b4a190f38fe3137a321be347c84a1375"
             }
           ]
         }
       },
       "changelog": {
-        "3.0.0": ["Check the Updates page"]
+        "3.0.0": ["Check the Updates page"],
+        "3.0.1": ["Move to TypesettingTools repository"]
       }
     },
     
@@ -499,20 +525,24 @@
       "description": "Copy and Fax Things. Occasionally perform a necroscopy.",
       "channels": {
         "master": {
-          "version": "4.1.0",
-          "released": "2018-06-24",
+          "version": "4.1.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "b25234859bc304d941b4c0a70a38345f11a55a21"
+              "sha1": "f6847e0573a6396c619d19346850b381038e7da0"
             }
           ]
         }
       },
       "changelog": {
-        "4.1.0": ["Check the Updates page"]
+        "4.1.0": ["Check the Updates page"],
+        "4.1.1": [
+          "Move to TypesettingTools repository",
+          "Fixed crash on splitting by marker"
+        ]
       }
     },
     
@@ -523,22 +553,23 @@
       "description": "Encode a clip with or without hardsubs",
       "channels": {
         "master": {
-          "version": "1.2.0",
-          "released": "2015-09-05",
+          "version": "1.2.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "865445160f3338da55f04a761e4dde819dbece37"
+              "sha1": "7fbbd67c2d5e9dbf0b6f7a75ae2c2bf5be22fb8e"
             }
           ]
         }
       },
       "changelog": {
-        "1.2.0": ["fixed an issue with the encode being deleted when not muxing audio; fixed some issues resulting from subtitles not being saved"],
+        "1.0.1": ["Added DespondencyControl"],
         "1.1.0": ["added option to mux the encode with audio"],
-        "1.0.1": ["Added DespondencyControl"]
+        "1.2.0": ["fixed an issue with the encode being deleted when not muxing audio; fixed some issues resulting from subtitles not being saved"],
+        "1.2.1": ["Move to TypesettingTools repository"]
       }
     },
     
@@ -549,20 +580,21 @@
       "description": "Muxes stuff using mkvmerge",
       "channels": {
         "master": {
-          "version": "1.1.0",
-          "released": "2015-05-26",
+          "version": "1.1.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "1d1be8a1135c35a31b79947227e45072bea3d348"
+              "sha1": "d9061746dc8af60af12cd9e868c80428f48a4c4d"
             }
           ]
         }
       },
       "changelog": {
-        "1.1.0": ["Added DespondencyControl"]
+        "1.1.0": ["Added DespondencyControl"],
+        "1.1.1": ["Move to TypesettingTools repository"]
       }
     },
     
@@ -573,20 +605,21 @@
       "description": "Checks your shitty script and tells you how bad it is",
       "channels": {
         "master": {
-          "version": "2.9.0",
-          "released": "2015-05-25",
+          "version": "2.9.1",
+          "released": "2022-07-12",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "53d9190850b917eaec1ab6287a3423cc8eb5a959"
+              "sha1": "ed74ade7c6efbcf165fce55bd3d1f689c5ed648d"
             }
           ]
         }
       },
       "changelog": {
-        "2.9.0": ["Added DependencyControl"]
+        "2.9.0": ["Added DependencyControl"],
+        "2.9.1": ["Move to TypesettingTools repository"]
       }
     }
         

--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -397,14 +397,14 @@
       "description": "Works with Fades",
       "channels": {
         "master": {
-          "version": "5.0.1",
-          "released": "2022-07-12",
+          "version": "5.0.2",
+          "released": "2023-02-24",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "b8703f84c6411c7e8cc268e4882504e2f87e958b"
+              "sha1": "7ac44d6c10d4cb916e8fa8ace3d967ae506cec2b"
             }
           ]
         }
@@ -414,7 +414,8 @@
         "5.0.1": [
           "Move to TypesettingTools repository",
           "Change script_namespace to ua.FadeWorks"
-        ]
+        ],
+        "5.0.2": ["Fix off-by-one error for \\ko fades"]
       }
     },
     

--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "dependencyControlFeedFormatVersion": "0.2.0",
   "name": "unanimated's Automation Scripts",
   "description": "Secondary repository for most of unanimated's automation scripts.",

--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -2,8 +2,8 @@
   "dependencyControlFeedFormatVersion": "0.2.0",
   "name": "unanimated's Automation Scripts",
   "description": "Secondary repository for most of unanimated's automation scripts.",
-  "baseUrl": "https://github.com/unanimated/luaegisub",
-  "fileBaseUrl": "https://raw.githubusercontent.com/unanimated/luaegisub/@{channel}/@{namespace}",
+  "baseUrl": "https://github.com/TypesettingTools/unanimated-Aegisub-Scripts",
+  "fileBaseUrl": "https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/@{channel}/@{namespace}",
   "url": "@{baseUrl}",
   "maintainer": "unanimated",
   "macros": {

--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -222,7 +222,7 @@
         }
       },
       "changelog": {
-		"4.5.2": ["Follow user defined rounding for vector clips"],
+	"4.5.2": ["Follow user defined rounding for vector clips"],
         "4.5.1": ["Support for subpixel vector clips"],
         "4.5.0": ["Check the Updates page"]
       }

--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -216,7 +216,7 @@
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "93d9db6d328a660b8da507d0762bfa87e95be57f"
+              "sha1": "2fb823ab1f22b38d1181beacc73ef663874ad0fe"
             }
           ]
         }

--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -209,19 +209,20 @@
       "description": "Advanced metamorphosis of multidimensional coordinates",
       "channels": {
         "master": {
-          "version": "4.5.0",
-          "released": "2018-08-05",
+          "version": "4.5.1",
+          "released": "2020-08-22",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "c1aa30d3af93c7f33f05841a37cd4f9e13c84951"
+              "sha1": "93d9db6d328a660b8da507d0762bfa87e95be57f"
             }
           ]
         }
       },
       "changelog": {
+        "4.5.1": ["Support for subpixel vector clips"],
         "4.5.0": ["Check the Updates page"]
       }
     },

--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -216,7 +216,7 @@
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "23051f12ae6a9b0e4af8c90007db95339060d93a"
+              "sha1": "e7a4e9f28363aa2deb27c3eab112dbd7d2d1ac73"
             }
           ]
         }

--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -209,19 +209,20 @@
       "description": "Advanced metamorphosis of multidimensional coordinates",
       "channels": {
         "master": {
-          "version": "4.5.1",
-          "released": "2020-08-22",
+          "version": "4.5.2",
+          "released": "2022-04-24",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "2fb823ab1f22b38d1181beacc73ef663874ad0fe"
+              "sha1": "23051f12ae6a9b0e4af8c90007db95339060d93a"
             }
           ]
         }
       },
       "changelog": {
+		"4.5.2": ["Follow user defined rounding for vector clips"],
         "4.5.1": ["Support for subpixel vector clips"],
         "4.5.0": ["Check the Updates page"]
       }

--- a/ua.BlurAndGlow.lua
+++ b/ua.BlurAndGlow.lua
@@ -18,12 +18,11 @@ script_name="Blur and Glow"
 script_description="Add blur and/or glow to signs"
 script_author="unanimated"
 script_url="http://unanimated.xtreemhost.com/ts/blur-and-glow.lua"
-script_version="2.5"
+script_version="2.5.1"
 script_namespace="ua.BlurAndGlow"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-  script_version="2.5.0"
   depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.ChangeCase.lua
+++ b/ua.ChangeCase.lua
@@ -1,12 +1,11 @@
 script_name="Change Case"
 script_description="Capitalises text or makes it lowercase / uppercase"
 script_author="unanimated"
-script_version="3.0"
+script_version="3.0.1"
 script_namespace="ua.ChangeCase"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-  script_version="3.0.0"
   depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.Colorize.lua
+++ b/ua.Colorize.lua
@@ -2,7 +2,7 @@ script_name="Colourise"
 script_description="RGB Magic and HSL Sorcery"
 script_author="unanimated"
 script_version="5.0"
-script_namespace="ua.Colourise"
+script_namespace="ua.Colorize"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then

--- a/ua.Colorize.lua
+++ b/ua.Colorize.lua
@@ -7,7 +7,7 @@ script_namespace="ua.Colorize"
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
 	script_version="5.0.0"
-	depRec=DependencyControl{feed="https://raw.githubusercontent.com/unanimated/luaegisub/master/DependencyControl.json"}
+	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 
 info={}

--- a/ua.Colorize.lua
+++ b/ua.Colorize.lua
@@ -1,12 +1,11 @@
 script_name="Colourise"
 script_description="RGB Magic and HSL Sorcery"
 script_author="unanimated"
-script_version="5.0"
+script_version="5.0.1"
 script_namespace="ua.Colorize"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-	script_version="5.0.0"
 	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.Cycles.lua
+++ b/ua.Cycles.lua
@@ -3,12 +3,11 @@
 script_name="Cycles"
 script_description="Cycles blur, border, shadow, alpha, alignment, font spacing"
 script_author="unanimated"
-script_version="2.0"
+script_version="2.0.1"
 script_namespace="ua.Cycles"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-	script_version="2.0.0"
 	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.Cycles.lua
+++ b/ua.Cycles.lua
@@ -9,7 +9,7 @@ script_namespace="ua.Cycles"
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
 	script_version="2.0.0"
-	depRec=DependencyControl{feed="https://raw.githubusercontent.com/unanimated/luaegisub/master/DependencyControl.json"}
+	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 
 -- SETTINGS - You can change these sequences

--- a/ua.EncodeHardsub.lua
+++ b/ua.EncodeHardsub.lua
@@ -28,12 +28,11 @@
 script_name="Encode - Hardsub"
 script_description="Encode a clip with or without hardsubs"
 script_author="unanimated"
-script_version="1.2"
+script_version="1.2.1"
 script_namespace="ua.EncodeHardsub"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-  script_version="1.2.0"
   depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.FadeWorks.lua
+++ b/ua.FadeWorks.lua
@@ -1,12 +1,11 @@
 script_name="FadeWorkS"
 script_description="Makes pictograph overlays fade in and out of existence"
 script_author="unanimated"
-script_version="5.0"
+script_version="5.0.1"
 script_namespace="ua.FadeWorks"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-	script_version="5.0.0"
 	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.FadeWorks.lua
+++ b/ua.FadeWorks.lua
@@ -7,7 +7,7 @@ script_namespace="ua.FadeWorks"
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
 	script_version="5.0.0"
-	depRec=DependencyControl{feed="https://raw.githubusercontent.com/unanimated/luaegisub/master/DependencyControl.json"}
+	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 
 re=require'aegisub.re'

--- a/ua.FadeWorks.lua
+++ b/ua.FadeWorks.lua
@@ -489,12 +489,12 @@ function koko_da(subs,sel)
 	if not res.word then
 		matches=re.find(text,"[\\w[:punct:]][\\s\\\\*]*")
 		len=#matches
-		if fadin>=40 then ko=round(fadin/(len-1))/10 else ko=fadin end
+		if fadin>=40 then ko=round(fadin/len)/10 else ko=fadin end
 		text=re.sub(text,"([\\w[:punct:]])","{\\\\ko"..ko.."}\\1")
 	else	--word
 		matches=re.find(text,"[\\w[:punct:]]+[\\s\\\\*]*")
 		len=#matches
-		if fadin>=40 then ko=round(fadin/(len-1)/10) else ko=fadin end
+		if fadin>=40 then ko=round(fadin/len/10) else ko=fadin end
 		text=re.sub(text,"([\\w[:punct:]]+)","{\\\\ko"..ko.."}\\1")
 	end
 

--- a/ua.FadeWorks.lua
+++ b/ua.FadeWorks.lua
@@ -2,7 +2,7 @@ script_name="FadeWorkS"
 script_description="Makes pictograph overlays fade in and out of existence"
 script_author="unanimated"
 script_version="5.0"
-script_namespace="ua.Fadeworks"
+script_namespace="ua.FadeWorks"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then

--- a/ua.FadeWorks.lua
+++ b/ua.FadeWorks.lua
@@ -1,7 +1,7 @@
 script_name="FadeWorkS"
 script_description="Makes pictograph overlays fade in and out of existence"
 script_author="unanimated"
-script_version="5.0.1"
+script_version="5.0.2"
 script_namespace="ua.FadeWorks"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")

--- a/ua.HYDRA.lua
+++ b/ua.HYDRA.lua
@@ -5,12 +5,11 @@ script_description="A multi-headed typesetting beast. Scary as Hell."
 script_author="unanimated"
 script_url1="http://unanimated.hostfree.pw/ts/hydra.lua"
 script_url2="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/hydra.lua"
-script_version="6.1"
+script_version="6.1.1"
 script_namespace="ua.HYDRA"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-	script_version="6.1.0"
 	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.HYDRA.lua
+++ b/ua.HYDRA.lua
@@ -4,14 +4,14 @@ script_name="HYDRA"
 script_description="A multi-headed typesetting beast. Scary as Hell."
 script_author="unanimated"
 script_url1="http://unanimated.hostfree.pw/ts/hydra.lua"
-script_url2="https://raw.githubusercontent.com/unanimated/luaegisub/master/hydra.lua"
+script_url2="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/hydra.lua"
 script_version="6.1"
 script_namespace="ua.HYDRA"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
 	script_version="6.1.0"
-	depRec=DependencyControl{feed="https://raw.githubusercontent.com/unanimated/luaegisub/master/DependencyControl.json"}
+	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 
 re=require'aegisub.re'

--- a/ua.JoinSplitSnap.lua
+++ b/ua.JoinSplitSnap.lua
@@ -29,12 +29,11 @@ kfea=15		-- ends after
 script_name="Join / Split / Snap"
 script_description="Joins lines / splits lines / snaps to keyframes"
 script_author="unanimated"
-script_version="1.2"
+script_version="1.2.1"
 script_namespace="ua.JoinSplitSnap"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-  script_version="1.2.0"
   depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.JumpToNext.lua
+++ b/ua.JumpToNext.lua
@@ -7,12 +7,11 @@ script_name="Jump to Next"
 script_description="Jumps to next 'sign' in the subtitle grid"
 script_description2="Jumps to previous 'sign' in the subtitle grid"
 script_author="unanimated"
-script_version="2.0"
+script_version="2.0.1"
 script_namespace="ua.JumpToNext"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-  script_version="2.0.0"
   depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.LineBreaker.lua
+++ b/ua.LineBreaker.lua
@@ -9,7 +9,7 @@ script_namespace="ua.LineBreaker"
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
 	script_version="2.4.0"
-	depRec=DependencyControl{feed="https://raw.githubusercontent.com/unanimated/luaegisub/master/DependencyControl.json"}
+	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 
 re=require'aegisub.re'

--- a/ua.LineBreaker.lua
+++ b/ua.LineBreaker.lua
@@ -3,12 +3,11 @@
 script_name="Line Breaker"
 script_description="Breaks lines"
 script_author="unanimated"
-script_version="2.4"
+script_version="2.4.1"
 script_namespace="ua.LineBreaker"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-	script_version="2.4.0"
 	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.Masquerade.lua
+++ b/ua.Masquerade.lua
@@ -1,12 +1,11 @@
 script_name="Masquerade"
 script_description="Dark Elves with Blurry Masks Shifting in Motion"
 script_author="unanimated"
-script_version="3.0"
+script_version="3.0.1"
 script_namespace="ua.Masquerade"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-  script_version="3.0.0"
   depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.Masquerade.lua
+++ b/ua.Masquerade.lua
@@ -7,7 +7,7 @@ script_namespace="ua.Masquerade"
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
   script_version="3.0.0"
-  depRec=DependencyControl{feed="https://raw.githubusercontent.com/unanimated/luaegisub/master/DependencyControl.json"}
+  depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 
 hlp=[[	Full manual: http://unanimated.hostfree.pw/ts/scripts-manuals.htm#masquerade

--- a/ua.MultiCopy.lua
+++ b/ua.MultiCopy.lua
@@ -10,7 +10,7 @@ script_namespace="ua.MultiCopy"
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
 	script_version="4.0.0"
-	depRec=DependencyControl{feed="https://raw.githubusercontent.com/unanimated/luaegisub/master/DependencyControl.json"}
+	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 
 clipboard=require'aegisub.clipboard'

--- a/ua.MultiCopy.lua
+++ b/ua.MultiCopy.lua
@@ -4,12 +4,11 @@
 script_name="MultiCopy"
 script_description="Lossless transfer of data between compatible storage units"
 script_author="unanimated"
-script_version="4.0"
+script_version="4.0.1"
 script_namespace="ua.MultiCopy"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-	script_version="4.0.0"
 	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.MultiLineEditor.lua
+++ b/ua.MultiLineEditor.lua
@@ -3,12 +3,11 @@
 script_name="Multi-Line Editor"
 script_description="Multi-Line Editor"
 script_author="unanimated"
-script_version="1.8"
+script_version="1.8.1"
 script_namespace="ua.MultiLineEditor"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-	script_version="1.8.0"
 	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.MultiLineEditor.lua
+++ b/ua.MultiLineEditor.lua
@@ -9,7 +9,7 @@ script_namespace="ua.MultiLineEditor"
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
 	script_version="1.8.0"
-	depRec=DependencyControl{feed="https://raw.githubusercontent.com/unanimated/luaegisub/master/DependencyControl.json"}
+	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 
 re=require'aegisub.re'

--- a/ua.Multiplexer.lua
+++ b/ua.Multiplexer.lua
@@ -380,12 +380,11 @@
 script_name="Multiplexer"
 script_description="Muxes stuff using mkvmerge"
 script_author="unanimated"
-script_version="1.1"
+script_version="1.1.1"
 script_namespace="ua.Multiplexer"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-  script_version="1.1.0"
   depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.NecrosCopy.lua
+++ b/ua.NecrosCopy.lua
@@ -7,7 +7,7 @@ script_namespace="ua.NecrosCopy"
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
 	script_version="4.1.0"
-	depRec=DependencyControl{feed="https://raw.githubusercontent.com/unanimated/luaegisub/master/DependencyControl.json"}
+	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 
 re=require'aegisub.re'

--- a/ua.NecrosCopy.lua
+++ b/ua.NecrosCopy.lua
@@ -589,6 +589,7 @@ function splitbreak(subs,sel)
 				},{"Spaces","Tags","Marker","Skip","Cancel"},{close='Cancel'})
 			end
 			if P=="Cancel" then ak() end
+			breakit=false nmbr=rez.num mark=rez.mark
 			text=text:gsub("\\N","")
 			if P=="Spaces" then text=textreplace(text," "," \\N") end
 			if P=="Tags" then
@@ -602,7 +603,6 @@ function splitbreak(subs,sel)
 				text=stags..after
 			end
 			if rez.remember then applytoall=P end
-			breakit=false nmbr=rez.num mark=rez.mark
 			text=text:gsub("({\\[^}]*}) *\\N","\\N%1")
 		end
 	

--- a/ua.NecrosCopy.lua
+++ b/ua.NecrosCopy.lua
@@ -1,12 +1,11 @@
 script_name="NecrosCopy"
 script_description="Copy and fax things in the shadows while lines are splitting and breaking"
 script_author="reanimated"
-script_version="4.1"
+script_version="4.1.1"
 script_namespace="ua.NecrosCopy"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-	script_version="4.1.0"
 	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.QC.lua
+++ b/ua.QC.lua
@@ -1,12 +1,11 @@
 script_name="Quality Check"
 script_description="Quality Check"
 script_author="unanimated"
-script_version="2.9"
+script_version="2.9.1"
 script_namespace="ua.QC"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-  script_version="2.9.0"
   depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.Recalculator.lua
+++ b/ua.Recalculator.lua
@@ -19,7 +19,7 @@ script_namespace="ua.Recalculator"
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
 	script_version="4.0.0"
-	depRec=DependencyControl{feed="https://raw.githubusercontent.com/unanimated/luaegisub/master/DependencyControl.json"}
+	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 
 re=require'aegisub.re'

--- a/ua.Recalculator.lua
+++ b/ua.Recalculator.lua
@@ -13,12 +13,11 @@
 script_name="Recalculator"
 script_description="Incremental Reconstruction of Disassembled Elements"
 script_author="unanimated"
-script_version="4.0"
+script_version="4.0.1"
 script_namespace="ua.Recalculator"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-	script_version="4.0.0"
 	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.Relocator.lua
+++ b/ua.Relocator.lua
@@ -11,7 +11,7 @@ script_namespace="ua.Relocator"
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
 	script_version="4.5.2"
-	depRec=DependencyControl{feed="https://raw.githubusercontent.com/unanimated/luaegisub/master/DependencyControl.json"}
+	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 
 re=require'aegisub.re'

--- a/ua.Relocator.lua
+++ b/ua.Relocator.lua
@@ -5,12 +5,11 @@ script_name="Hyperdimensional Relocator"
 script_description="Advanced metamorphosis of multidimensional coordinates"
 script_author="reanimated"
 script_url="http://unanimated.hostfree.pw/ts/relocator.lua"
-script_version="4.5.2"
+script_version="4.5.3"
 script_namespace="ua.Relocator"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-	script_version="4.5.2"
 	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.Relocator.lua
+++ b/ua.Relocator.lua
@@ -1450,7 +1450,6 @@ function modifier(subs,sel,act)
 		end
 		if text:match("\\i?clip") and res.rnd=="all" or text:match("\\i?clip") and res.rnd=="clip" then
 		  for klip in text:gmatch("\\i?clip%([^%)]+%)") do
-		    rrr=rr
 		    klip2=klip:gsub("([%d.-]+)",function(c) return round(c,rrr) end)
 		    text=text:gsub(esc(klip),klip2)
 		  end

--- a/ua.Relocator.lua
+++ b/ua.Relocator.lua
@@ -10,7 +10,7 @@ script_namespace="ua.Relocator"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-	script_version="4.5.0"
+	script_version="4.5.1"
 	depRec=DependencyControl{feed="https://raw.githubusercontent.com/unanimated/luaegisub/master/DependencyControl.json"}
 end
 
@@ -396,8 +396,8 @@ function positron(subs,sel)
 	-- clip to fax
 	if res.posi=="clip to fax" then
 		if not text:match("\\i?clip%(m") and not text:match("//i?clip%(m") then t_error("Missing \\clip on line #"..i-line0..".\nAborting.",1) end
-		cx1,cy1,cx2,cy2,cx3,cy3,cx4,cy4=text:match("clip%(m ([%d%-]+) ([%d%-]+) l ([%d%-]+) ([%d%-]+) ([%d%-]+) ([%d%-]+) ([%d%-]+) ([%d%-]+)")
-		if not cx1 then cx1,cy1,cx2,cy2=text:match("clip%(m ([%d%-]+) ([%d%-]+) l ([%d%-]+) ([%d%-]+)") end
+		cx1,cy1,cx2,cy2,cx3,cy3,cx4,cy4=text:match("clip%(m ([%d.-]+) ([%d.-]+) l ([%d.-]+) ([%d.-]+) ([%d.-]+) ([%d.-]+) ([%d.-]+) ([%d.-]+)")
+		if not cx1 then cx1,cy1,cx2,cy2=text:match("clip%(m ([%d.-]+) ([%d.-]+) l ([%d.-]+) ([%d.-]+)") end
 		if not cx1 then t_error("Line #"..i-line0..": Not enough clip points. 2 required.",1) end
 		sr=stylechk(subs,line.style)
 		rota=nontra:match("^{[^}]-\\frz([%d.-]+)") or sr.angle
@@ -446,8 +446,8 @@ function positron(subs,sel)
 	-- clip to frz
 	if res.posi=="clip to frz" then
 		if not text:match("\\i?clip%(m") and not text:match("//i?clip%(m") then t_error("Missing \\clip on line #"..i-line0..".\nAborting.",1) end
-		cx1,cy1,cx2,cy2,cx3,cy3,cx4,cy4=text:match("clip%(m ([%d%-]+) ([%d%-]+) l ([%d%-]+) ([%d%-]+) ([%d%-]+) ([%d%-]+) ([%d%-]+) ([%d%-]+)")
-		if not cx1 then cx1,cy1,cx2,cy2=text:match("clip%(m ([%d%-]+) ([%d%-]+) l ([%d%-]+) ([%d%-]+)") end
+		cx1,cy1,cx2,cy2,cx3,cy3,cx4,cy4=text:match("clip%(m ([%d.-]+) ([%d.-]+) l ([%d.-]+) ([%d.-]+) ([%d.-]+) ([%d.-]+) ([%d.-]+) ([%d.-]+)")
+		if not cx1 then cx1,cy1,cx2,cy2=text:match("clip%(m ([%d.-]+) ([%d.-]+) l ([%d.-]+) ([%d.-]+)") end
 		if not cx1 then t_error("Line #"..i-line0..": Not enough clip points. 2 required.",1) end
 		local ad,op,tang,ang1,rota,ad2,op2,tang2,ang2,rota2
 		ad=cx2-cx1
@@ -473,7 +473,7 @@ function positron(subs,sel)
 	-- clip to reposition
 	if res.posi=="clip to reposition" then
 		if not text:match("\\i?clip%(m") and not text:match("//i?clip%(m") then t_error("Missing \\clip on line #"..i-line0..".\nAborting.",1) end
-		cx1,cy1,cx2,cy2=text:match("clip%(m ([%d%-]+) ([%d%-]+) l ([%d%-]+) ([%d%-]+)")
+		cx1,cy1,cx2,cy2=text:match("clip%(m ([%d.-]+) ([%d.-]+) l ([%d.-]+) ([%d.-]+)")
 		if not cx1 then t_error("Line #"..i-line0..": Not enough clip points. 2 required.",1) end
 		repo1=cx2-cx1 repo2=cy2-cy1
 		text=text:gsub("\\i?clip%b()","")
@@ -1121,8 +1121,8 @@ function bilocator(subs,sel)
 		else movt1,movt2=gettimes(start,endt) end
 		if res.times then M=","..movt1..","..movt2 else M="" end
 		if not text:match("\\i?clip") and not text:match("//i?clip") then t_error("Missing \\clip on line #"..i-line0..". Aborting.",1) end
-		cx1,cy1,cx2,cy2,cx3,cy3,cx4,cy4=text:match("clip%(m ([%d%-]+) ([%d%-]+) l ([%d%-]+) ([%d%-]+) ([%d%-]+) ([%d%-]+) ([%d%-]+) ([%d%-]+)")
-		if not cx1 then cx1,cy1,cx2,cy2=text:match("clip%(m ([%d%-]+) ([%d%-]+) l ([%d%-]+) ([%d%-]+)") end
+		cx1,cy1,cx2,cy2,cx3,cy3,cx4,cy4=text:match("clip%(m ([%d.-]+) ([%d.-]+) l ([%d.-]+) ([%d.-]+) ([%d.-]+) ([%d.-]+) ([%d.-]+) ([%d.-]+)")
+		if not cx1 then cx1,cy1,cx2,cy2=text:match("clip%(m ([%d.-]+) ([%d.-]+) l ([%d.-]+) ([%d.-]+)") end
 		if not cx1 then t_error("Line #"..i-line0..": Not enough clip points. Min. 2 required.",1) end
 		if cx4 then
 			point1x=(cx2+cx1)/2
@@ -1499,7 +1499,7 @@ function modifier(subs,sel,act)
 	if res.mod=="calculate origin" then
 		local c={}
 		local c2={}
-		x1,y1,x2,y2,x3,y3,x4,y4=text:match("clip%(m ([%d%-]+) ([%d%-]+) l ([%d%-]+) ([%d%-]+) ([%d%-]+) ([%d%-]+) ([%d%-]+) ([%d%-]+)")
+		x1,y1,x2,y2,x3,y3,x4,y4=text:match("clip%(m ([%d.-]+) ([%d.-]+) l ([%d.-]+) ([%d.-]+) ([%d.-]+) ([%d.-]+) ([%d.-]+) ([%d.-]+)")
 		if not x1 then t_error("Line #"..i-line0..": vectorial clip with 4 points required.\nAborting.",1) end
 		cor1={x=tonumber(x1),y=tonumber(y1)} table.insert(c,cor1) table.insert(c2,cor1)
 		cor2={x=tonumber(x2),y=tonumber(y2)} table.insert(c,cor2) table.insert(c2,cor2)
@@ -1672,7 +1672,7 @@ function modifier(subs,sel,act)
 				local xx,yy=text:match("\\pos%(([%d.-]+),([%d.-]+)%)")
 				xx=round(xx) yy=round(yy)
 				coord=klip:match("\\clip%(m ([^%)]+)%)")
-				coord2=coord:gsub("([%d%-]+) ([%d%-]+)",function(a,b) return round(a*scx/100+xx).." "..round(b*scy/100+yy) end)
+				coord2=coord:gsub("([%d.-]+) ([%d.-]+)",function(a,b) return round(a*scx/100+xx).." "..round(b*scy/100+yy) end)
 				klip=klip:gsub(esc(coord),coord2)
 			end
 			if nopos then text=text:gsub("^{","{\\pos(0,0)") end
@@ -1686,7 +1686,7 @@ function modifier(subs,sel,act)
 			local xx,yy=text:match("\\pos%(([%d.-]+),([%d.-]+)%)")
 				xx=round(xx) yy=round(yy)
 				coord=klip:match("m ([%d%a%s%-]+)")
-				coord2=coord:gsub("([%d%-]+)%s([%d%-]+)",function(a,b) return a-xx.." "..b-yy end)
+				coord2=coord:gsub("([%d.-]+)%s([%d.-]+)",function(a,b) return a-xx.." "..b-yy end)
 				coord=coord:gsub("%-","%%-")
 				klip=klip:gsub(coord,coord2)
 			end
@@ -2131,7 +2131,7 @@ lastags1=""
 		--logg("\n val1: "..val1.."  valf: "..valf.."  tpart: "..tpart.."  twhole: "..twhole)
 	end
 	-- clip
-	if tra:match("\\i?clip%([%d%-]") then
+	if tra:match("\\i?clip%([%d.-]") then
 	ctype,c1,c2,c3,c4=nontra:match("(\\i?clip%()([%d.-]+),([%d.-]+),([%d.-]+),([%d.-]+)")
 	if not ctype then t_error("Error. Looks like you're transforming a clip that's not set in the first place.\n> "..tags,1) end
 	ktype,k1,k2,k3,k4=tra:match("(\\i?clip%()([%d.-]+),([%d.-]+),([%d.-]+),([%d.-]+)")

--- a/ua.Relocator.lua
+++ b/ua.Relocator.lua
@@ -5,12 +5,12 @@ script_name="Hyperdimensional Relocator"
 script_description="Advanced metamorphosis of multidimensional coordinates"
 script_author="reanimated"
 script_url="http://unanimated.hostfree.pw/ts/relocator.lua"
-script_version="4.5"
+script_version="4.5.2"
 script_namespace="ua.Relocator"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-	script_version="4.5.1"
+	script_version="4.5.2"
 	depRec=DependencyControl{feed="https://raw.githubusercontent.com/unanimated/luaegisub/master/DependencyControl.json"}
 end
 
@@ -1450,7 +1450,7 @@ function modifier(subs,sel,act)
 		end
 		if text:match("\\i?clip") and res.rnd=="all" or text:match("\\i?clip") and res.rnd=="clip" then
 		  for klip in text:gmatch("\\i?clip%([^%)]+%)") do
-		    if klip:match("m") then rrr=0 else rrr=rr end
+		    rrr=rr
 		    klip2=klip:gsub("([%d.-]+)",function(c) return round(c,rrr) end)
 		    text=text:gsub(esc(klip),klip2)
 		  end

--- a/ua.Relocator.lua
+++ b/ua.Relocator.lua
@@ -1450,7 +1450,7 @@ function modifier(subs,sel,act)
 		end
 		if text:match("\\i?clip") and res.rnd=="all" or text:match("\\i?clip") and res.rnd=="clip" then
 		  for klip in text:gmatch("\\i?clip%([^%)]+%)") do
-		    klip2=klip:gsub("([%d.-]+)",function(c) return round(c,rrr) end)
+		    klip2=klip:gsub("([%d.-]+)",function(c) return round(c,rr) end)
 		    text=text:gsub(esc(klip),klip2)
 		  end
 		end

--- a/ua.ScriptCleanup.lua
+++ b/ua.ScriptCleanup.lua
@@ -3,12 +3,11 @@
 script_name="Script Cleanup"
 script_description="Garbage disposal and elimination of incriminating evidence"
 script_author="unanimated"
-script_version="5.0"
+script_version="5.0.1"
 script_namespace="ua.ScriptCleanup"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-	script_version="5.0.0"
 	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.ScriptCleanup.lua
+++ b/ua.ScriptCleanup.lua
@@ -9,7 +9,7 @@ script_namespace="ua.ScriptCleanup"
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
 	script_version="5.0.0"
-	depRec=DependencyControl{feed="https://raw.githubusercontent.com/unanimated/luaegisub/master/DependencyControl.json"}
+	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 
 dont_delete_empty_tags=false	-- option to not delete {}

--- a/ua.Selectrix.lua
+++ b/ua.Selectrix.lua
@@ -3,12 +3,11 @@
 script_name="Selectricks"
 script_description="Selectricks and Sortricks"
 script_author="unanimated"
-script_version="3.4"
+script_version="3.4.1"
 script_namespace="ua.Selectrix"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-	script_version="3.4.0"
 	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.Selectrix.lua
+++ b/ua.Selectrix.lua
@@ -9,7 +9,7 @@ script_namespace="ua.Selectrix"
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
 	script_version="3.4.0"
-	depRec=DependencyControl{feed="https://raw.githubusercontent.com/unanimated/luaegisub/master/DependencyControl.json"}
+	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 
 re=require'aegisub.re'

--- a/ua.ShiftCut.lua
+++ b/ua.ShiftCut.lua
@@ -11,7 +11,7 @@ re=require'aegisub.re'
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
 	script_version="3.1.0"
-	depRec=DependencyControl{feed="https://raw.githubusercontent.com/unanimated/luaegisub/master/DependencyControl.json"}
+	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 
 function shiftcut(subs,sel,act)

--- a/ua.ShiftCut.lua
+++ b/ua.ShiftCut.lua
@@ -3,14 +3,13 @@
 script_name="ShiftCut"
 script_description="Time Machine. finish sentences before they started. Travels back in time to"
 script_author="unanimated"
-script_version="3.1"
+script_version="3.1.1"
 script_namespace="ua.ShiftCut"
 
 re=require'aegisub.re'
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-	script_version="3.1.0"
 	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.Significance.lua
+++ b/ua.Significance.lua
@@ -1,12 +1,11 @@
 script_name="Significance"
 script_description="Import stuff, number stuff, chapter stuff, replace stuff, do a significant amount of other stuff to stuff."
 script_author="unanimated"
-script_version="3.5"
+script_version="3.5.1"
 script_namespace="ua.Significance"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-	script_version="3.5.0"
 	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.Significance.lua
+++ b/ua.Significance.lua
@@ -7,7 +7,7 @@ script_namespace="ua.Significance"
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
 	script_version="3.5.0"
-	depRec=DependencyControl{feed="https://raw.githubusercontent.com/unanimated/luaegisub/master/DependencyControl.json"}
+	depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 
 clipboard=require("aegisub.clipboard")

--- a/ua.TimeSigns.lua
+++ b/ua.TimeSigns.lua
@@ -5,12 +5,11 @@
 script_name="Time Signs"
 script_description="Rough-times signs from TS timecodes"
 script_author="unanimated"
-script_version="2.8"
+script_version="2.8.1"
 script_namespace="ua.TimeSigns"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-  script_version="2.8.0"
   depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 

--- a/ua.iBus.lua
+++ b/ua.iBus.lua
@@ -3,12 +3,11 @@
 script_name="iBus"
 script_description="Italy Bold Under Strike"
 script_author="unanimated"
-script_version="1.7"
+script_version="1.7.1"
 script_namespace="ua.iBus"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-  script_version="1.7.0"
   depRec=DependencyControl{feed="https://raw.githubusercontent.com/TypesettingTools/unanimated-Aegisub-Scripts/master/DependencyControl.json"}
 end
 


### PR DESCRIPTION
This PR aims to cleanup the currently quite messy DependencyControl situation in this repo. This includes the following changes:
- Merges upstream changes from [unanimated/luaegisub](https://github.com/unanimated/luaegisub)
- Merges https://github.com/unanimated/luaegisub/pull/15
- Fixes `script_namespace` of FadeWorkS and Colourise which caused the macros to show up twice in DependencyControl interfaces after installing
- Merges https://github.com/TypesettingTools/unanimated-Aegisub-Scripts/pull/1, which will prevent some invalid hash issues. Currently the feed from this repo is in DependencyControl, but the files get downloaded from `unanimated/luaegisub`. This currently causes a hash mismatch when installing Relocator.
- Remove UTF-8 BOM in depctrl feed (invalid JSON per specification)
- Bump minor version of all macros and update hashes in depctrl feed